### PR TITLE
Show new chat landing view in main panel

### DIFF
--- a/scripts/sidebar.js
+++ b/scripts/sidebar.js
@@ -210,7 +210,7 @@
     };
   };
 
-  const NEW_CHAT_OVERLAY_ID = 'new-chat-overlay';
+  const NEW_CHAT_OVERLAY_ID = 'new-chat-view';
   const NEW_CHAT_INPUT_SELECTOR = '[data-new-chat-input]';
 
   const overlayState = {
@@ -218,6 +218,65 @@
   };
 
   const getMainContent = () => document.getElementById('main-content');
+  const getRightPanel = () => document.getElementById('right-panel');
+
+  const hideMainSiblings = (overlay) => {
+    const main = getMainContent();
+    if (!main || !overlay) {
+      return;
+    }
+
+    Array.from(main.children).forEach((child) => {
+      if (!(child instanceof HTMLElement) || child === overlay) {
+        return;
+      }
+
+      if (!child.classList.contains('hidden')) {
+        child.dataset.newChatHidden = 'true';
+        child.classList.add('hidden');
+      }
+    });
+  };
+
+  const restoreMainSiblings = () => {
+    const main = getMainContent();
+    if (!main) {
+      return;
+    }
+
+    Array.from(main.children).forEach((child) => {
+      if (!(child instanceof HTMLElement)) {
+        return;
+      }
+
+      if (child.dataset.newChatHidden === 'true') {
+        child.classList.remove('hidden');
+        delete child.dataset.newChatHidden;
+      }
+    });
+  };
+
+  const hideRightPanel = () => {
+    const panel = getRightPanel();
+    if (!panel || panel.classList.contains('hidden')) {
+      return;
+    }
+
+    panel.dataset.newChatHidden = 'true';
+    panel.classList.add('hidden');
+  };
+
+  const restoreRightPanel = () => {
+    const panel = getRightPanel();
+    if (!panel) {
+      return;
+    }
+
+    if (panel.dataset.newChatHidden === 'true') {
+      panel.classList.remove('hidden');
+      delete panel.dataset.newChatHidden;
+    }
+  };
 
   const findOverlay = () => {
     const main = getMainContent();
@@ -261,6 +320,9 @@
     overlay.classList.add('hidden');
     overlay.setAttribute('aria-hidden', 'true');
 
+    restoreMainSiblings();
+    restoreRightPanel();
+
     const main = getMainContent();
     if (main) {
       delete main.dataset.newChatVisible;
@@ -278,131 +340,111 @@
       return null;
     }
 
-    main.classList.add('relative');
-
     const overlay = document.createElement('div');
     overlay.id = NEW_CHAT_OVERLAY_ID;
-    overlay.className = 'absolute inset-0 z-20 hidden overflow-y-auto bg-white/95 backdrop-blur-sm';
-    overlay.setAttribute('role', 'dialog');
+    overlay.className = 'flex-1 flex flex-col bg-white hidden';
+    overlay.setAttribute('role', 'region');
     overlay.setAttribute('aria-hidden', 'true');
     overlay.setAttribute('aria-labelledby', `${NEW_CHAT_OVERLAY_ID}-heading`);
     overlay.setAttribute('aria-describedby', `${NEW_CHAT_OVERLAY_ID}-description`);
 
-    const closeButton = document.createElement('button');
-    closeButton.type = 'button';
-    closeButton.className = 'absolute top-6 right-6 text-gray-400 hover:text-gray-600 transition-colors';
-    closeButton.innerHTML = '<span class="sr-only">Close new chat</span><i class="fa-solid fa-xmark text-lg"></i>';
-    closeButton.addEventListener('click', hideOverlay);
+    overlay.innerHTML = `
+      <header id="new-chat-header" class="flex items-center justify-between h-16 border-b border-gray-200 px-6 bg-white">
+          <div class="flex items-center space-x-4">
+              <h2 id="${NEW_CHAT_OVERLAY_ID}-heading" class="text-lg font-semibold text-gray-800">New Chat</h2>
+          </div>
+          <div class="flex items-center space-x-3">
+              <button class="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all" type="button">
+                  <i class="fa-solid fa-share-nodes"></i>
+              </button>
+              <button class="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all" type="button">
+                  <i class="fa-solid fa-download"></i>
+              </button>
+              <button class="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all" type="button">
+                  <i class="fa-solid fa-ellipsis-vertical"></i>
+              </button>
+          </div>
+      </header>
 
-    const container = document.createElement('div');
-    container.className = 'min-h-full flex flex-col items-center justify-center text-center gap-6 px-4 py-16';
+      <div id="new-chat-messages" class="flex-1 overflow-y-auto p-6 space-y-6">
+          <div id="new-chat-welcome" class="text-center py-16">
+              <div class="w-20 h-20 bg-navy rounded-full flex items-center justify-center mx-auto mb-6">
+                  <i class="fa-solid fa-robot text-white text-3xl"></i>
+              </div>
+              <h3 id="${NEW_CHAT_OVERLAY_ID}-description" class="text-2xl font-semibold text-gray-800 mb-3">Start a New Conversation</h3>
+              <p class="text-gray-600 max-w-lg mx-auto text-lg">I'm ready to help you with any questions or tasks. What would you like to work on today?</p>
+              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-8 max-w-4xl mx-auto">
+                  <div class="bg-gray-50 rounded-xl p-6 hover:bg-gray-100 cursor-pointer transition-all">
+                      <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-3">
+                          <i class="fa-solid fa-lightbulb text-blue-600 text-xl"></i>
+                      </div>
+                      <h4 class="font-semibold text-gray-800 mb-2">Generate Ideas</h4>
+                      <p class="text-sm text-gray-600">Brainstorm creative solutions and innovative concepts</p>
+                  </div>
+                  <div class="bg-gray-50 rounded-xl p-6 hover:bg-gray-100 cursor-pointer transition-all">
+                      <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-3">
+                          <i class="fa-solid fa-code text-green-600 text-xl"></i>
+                      </div>
+                      <h4 class="font-semibold text-gray-800 mb-2">Code Review</h4>
+                      <p class="text-sm text-gray-600">Analyze and improve your code quality</p>
+                  </div>
+                  <div class="bg-gray-50 rounded-xl p-6 hover:bg-gray-100 cursor-pointer transition-all">
+                      <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-3">
+                          <i class="fa-solid fa-file-text text-purple-600 text-xl"></i>
+                      </div>
+                      <h4 class="font-semibold text-gray-800 mb-2">Write Documentation</h4>
+                      <p class="text-sm text-gray-600">Create clear and comprehensive documentation</p>
+                  </div>
+                  <div class="bg-gray-50 rounded-xl p-6 hover:bg-gray-100 cursor-pointer transition-all">
+                      <div class="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center mx-auto mb-3">
+                          <i class="fa-solid fa-chart-bar text-orange-600 text-xl"></i>
+                      </div>
+                      <h4 class="font-semibold text-gray-800 mb-2">Analyze Data</h4>
+                      <p class="text-sm text-gray-600">Extract insights from your data sets</p>
+                  </div>
+                  <div class="bg-gray-50 rounded-xl p-6 hover:bg-gray-100 cursor-pointer transition-all">
+                      <div class="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center mx-auto mb-3">
+                          <i class="fa-solid fa-bug text-red-600 text-xl"></i>
+                      </div>
+                      <h4 class="font-semibold text-gray-800 mb-2">Debug Issues</h4>
+                      <p class="text-sm text-gray-600">Identify and solve technical problems</p>
+                  </div>
+                  <div class="bg-gray-50 rounded-xl p-6 hover:bg-gray-100 cursor-pointer transition-all">
+                      <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mx-auto mb-3">
+                          <i class="fa-solid fa-tasks text-indigo-600 text-xl"></i>
+                      </div>
+                      <h4 class="font-semibold text-gray-800 mb-2">Plan Projects</h4>
+                      <p class="text-sm text-gray-600">Organize tasks and create project roadmaps</p>
+                  </div>
+              </div>
+          </div>
+      </div>
 
-    const heading = document.createElement('h2');
-    heading.id = `${NEW_CHAT_OVERLAY_ID}-heading`;
-    heading.className = 'text-3xl sm:text-4xl font-semibold text-gray-900';
-    heading.textContent = 'Welcome to AI Assistant';
+      <div id="new-chat-input-area" class="border-t border-gray-200 p-4 bg-white">
+          <div class="max-w-4xl mx-auto">
+              <div class="relative flex items-center w-full bg-white border border-gray-200 rounded-full shadow-sm p-2 transition-all duration-200 focus-within:ring-2 focus-within:ring-navy/50">
+                  <i class="fa-solid fa-plus text-gray-500 pl-4 pr-2"></i>
+                  <textarea id="new-chat-input" placeholder="How can I help you today?" rows="1" class="flex-1 w-full p-2 bg-transparent border-none resize-none focus:ring-0 text-sm text-gray-800 placeholder-gray-500" data-new-chat-input="true"></textarea>
+                  <div class="flex items-center space-x-1 pr-2">
+                      <button class="w-10 h-10 flex items-center justify-center text-gray-500 hover:text-navy hover:bg-gray-100 rounded-full transition-all" type="button">
+                          <i class="fa-solid fa-microphone text-lg"></i>
+                      </button>
+                      <button class="w-10 h-10 flex items-center justify-center bg-gray-200 text-gray-600 rounded-full hover:bg-navy hover:text-white transition-all control-btn" type="button">
+                          <i class="fa-solid fa-arrow-up"></i>
+                      </button>
+                  </div>
+              </div>
+          </div>
+      </div>
+    `;
 
-    const description = document.createElement('p');
-    description.id = `${NEW_CHAT_OVERLAY_ID}-description`;
-    description.className = 'text-base sm:text-lg text-gray-600 max-w-2xl';
-    description.textContent = "I'm here to help you with product requirements, documentation, and project planning. How can I assist you today?";
-
-    const form = document.createElement('form');
-    form.className = 'w-full max-w-3xl mt-10';
-    form.setAttribute('aria-label', 'Start a new chat with the AI assistant');
-    form.addEventListener('submit', (event) => {
-      event.preventDefault();
-    });
-
-    const composerFrame = document.createElement('div');
-    composerFrame.className = 'border border-gray-200 bg-white rounded-3xl shadow-lg p-4';
-
-    const composerContainer = document.createElement('div');
-    composerContainer.className = 'max-w-4xl mx-auto';
-
-    const attachmentsPreview = document.createElement('div');
-    attachmentsPreview.className = 'flex flex-wrap gap-2 mb-3 hidden';
-
-    const relativeContainer = document.createElement('div');
-    relativeContainer.className = 'relative';
-
-    const dropOverlay = document.createElement('div');
-    dropOverlay.className = 'drop-overlay hidden absolute inset-0 rounded-3xl border-2 border-dashed border-navy/40 bg-white/80 flex items-center justify-center text-navy font-medium z-20';
-    dropOverlay.textContent = 'Drop files to attach';
-
-    const inputWrapper = document.createElement('div');
-    inputWrapper.className = 'relative flex items-center w-full bg-white border border-gray-200 rounded-full shadow-sm p-2 transition-all duration-200 focus-within:ring-2 focus-within:ring-navy/50';
-
-    const attachmentButton = document.createElement('button');
-    attachmentButton.type = 'button';
-    attachmentButton.className = 'w-10 h-10 flex items-center justify-center text-gray-500 hover:text-navy hover:bg-gray-100 rounded-full transition-all ml-2';
-    attachmentButton.innerHTML = '<i class="fa-solid fa-plus text-lg"></i>';
-
-    const textarea = document.createElement('textarea');
-    textarea.className = 'flex-1 w-full p-2 bg-transparent border-none resize-none focus:ring-0 text-sm text-gray-800 placeholder-gray-500';
-    textarea.setAttribute('rows', '1');
-    const existingPlaceholder = document.querySelector('#chat-input')?.getAttribute('placeholder');
-    textarea.setAttribute('placeholder', existingPlaceholder || 'Message the assistant...');
-    textarea.setAttribute('aria-label', existingPlaceholder || 'Message the assistant');
-    textarea.setAttribute('data-new-chat-input', 'true');
-    textarea.addEventListener('input', () => autoResizeTextarea(textarea));
-
-    const actions = document.createElement('div');
-    actions.className = 'flex items-center space-x-1 pr-2';
-
-    const voiceButton = document.createElement('button');
-    voiceButton.type = 'button';
-    voiceButton.className = 'w-10 h-10 flex items-center justify-center text-gray-500 hover:text-navy hover:bg-gray-100 rounded-full transition-all shrink-0';
-    voiceButton.innerHTML = '<i class="fa-solid fa-microphone text-lg"></i>';
-
-    const submitButton = document.createElement('button');
-    submitButton.type = 'submit';
-    submitButton.className = 'w-10 h-10 flex items-center justify-center bg-gray-200 text-gray-600 rounded-full hover:bg-navy hover:text-white transition-all control-btn shrink-0';
-    submitButton.innerHTML = '<span class="sr-only">Send message</span><i class="fa-solid fa-arrow-up"></i>';
-
-    const commandMenu = document.createElement('div');
-    commandMenu.className = 'command-menu hidden absolute bottom-full left-16 mb-3 w-72 bg-white rounded-2xl border border-gray-200 overflow-hidden z-30';
-    commandMenu.innerHTML = [
-      '<div class="px-4 py-3 border-b border-gray-100">',
-      '<p class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Slash commands</p>',
-      '</div>',
-      '<ul class="max-h-64 overflow-y-auto py-2"></ul>',
-    ].join('');
-
-    const attachmentMenu = document.createElement('div');
-    attachmentMenu.className = 'hidden absolute bottom-full left-0 mb-3 w-60 bg-white rounded-2xl border border-gray-200 shadow-xl z-30';
-    attachmentMenu.innerHTML = [
-      '<button type="button" class="w-full flex items-center space-x-3 px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 transition-colors">',
-      '<i class="fa-solid fa-arrow-up-from-bracket text-navy"></i>',
-      '<span>Upload from computer</span>',
-      '</button>',
-      '<button type="button" class="w-full flex items-center space-x-3 px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 transition-colors">',
-      '<i class="fa-solid fa-link text-navy"></i>',
-      '<span>Add reference link</span>',
-      '</button>',
-      '<button type="button" class="w-full flex items-center space-x-3 px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 transition-colors">',
-      '<i class="fa-solid fa-note-sticky text-navy"></i>',
-      '<span>Add quick note</span>',
-      '</button>',
-    ].join('');
-
-    const fileInput = document.createElement('input');
-    fileInput.type = 'file';
-    fileInput.multiple = true;
-    fileInput.className = 'hidden';
-
-    actions.append(voiceButton, submitButton);
-    inputWrapper.append(attachmentButton, textarea, actions, commandMenu, attachmentMenu);
-    relativeContainer.append(dropOverlay, inputWrapper);
-    composerContainer.append(attachmentsPreview, relativeContainer);
-    composerFrame.append(composerContainer, fileInput);
-    form.appendChild(composerFrame);
-
-    container.append(heading, description, form);
-    overlay.append(closeButton, container);
     main.appendChild(overlay);
 
-    overlayState.textarea = textarea;
+    const textarea = overlay.querySelector('#new-chat-input');
+    if (textarea) {
+      textarea.addEventListener('input', () => autoResizeTextarea(textarea));
+      overlayState.textarea = textarea;
+    }
 
     return overlay;
   };
@@ -418,14 +460,26 @@
     overlay.classList.remove('hidden');
     overlay.setAttribute('aria-hidden', 'false');
 
+    hideMainSiblings(overlay);
+    hideRightPanel();
+
     const main = getMainContent();
     if (main) {
       main.dataset.newChatVisible = 'true';
     }
 
+    const chatHistory = window.AIAssistant?.chatHistory;
+    if (chatHistory && typeof chatHistory.createChat === 'function') {
+      const activeLink = document.body?.dataset?.activeSidebarLink || '';
+      const projectId = activeLink && activeLink.startsWith('project-') ? activeLink : null;
+      chatHistory.createChat({ title: 'New Chat', projectId });
+    }
+
     const textarea = overlayState.textarea || overlay.querySelector(NEW_CHAT_INPUT_SELECTOR);
     if (textarea) {
       overlayState.textarea = textarea;
+      textarea.value = '';
+      textarea.style.height = '';
       autoResizeTextarea(textarea);
       textarea.focus();
     }


### PR DESCRIPTION
## Summary
- replace the previous modal overlay with an inline new chat landing view that matches the requested layout
- hide existing conversation content and the right sidebar while the new chat view is active and seed a placeholder "New Chat" entry in the chat list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e48f9baaf8832dafd9abac230ee736